### PR TITLE
Fix Github URL on homepage

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,7 +7,7 @@ import icon_slack from '../img/icon_slack.svg';
 export default () => {
   const icons = [
     { href: 'https://slack.openmined.org/', icon: icon_slack },
-    { href: 'httpL//github.com/OpenMined/pysyft', icon: icon_github },
+    { href: 'https://github.com/OpenMined/pysyft', icon: icon_github },
     {
       href: 'https://www.linkedin.com/company/openmined/',
       icon: icon_linkedin,


### PR DESCRIPTION
## Description
Quick fix for Github repo URL in upper right corner of the homepage.

## Affected Dependencies
N/A

## How has this been tested?
Local testing

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
