### PR TITLE
Remove duplicate line in PM job description

### DIFF
--- a/src/routes/TPM.jsx
+++ b/src/routes/TPM.jsx
@@ -109,9 +109,6 @@ export default () => {
         <li>
           Passion or experience working with AI Safety or language models.
         </li>
-        <li>
-          Passion or experience working with AI Safety or language models.
-        </li>
         <li>Contributions to open-source projects.</li>
       </ul>
       <br />


### PR DESCRIPTION
## Description
Removes a duplicate line from the project manager role description.

## Affected Dependencies
N/A

## How has this been tested?
N/A

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
